### PR TITLE
Fix "move" file reporting as a create event

### DIFF
--- a/watcher_test.go
+++ b/watcher_test.go
@@ -485,7 +485,7 @@ func TestListFiles(t *testing.T) {
 	w := New()
 	w.AddRecursive(testDir)
 
-	fileList := w.retrieveFileList()
+	_, fileList := w.retrieveFileList()
 	if fileList == nil {
 		t.Error("expected file list to not be empty")
 	}
@@ -895,7 +895,7 @@ func BenchmarkListFiles(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		fileList := w.retrieveFileList()
+		_, fileList := w.retrieveFileList()
 		if fileList == nil {
 			b.Fatal("expected file list to not be empty")
 		}
@@ -914,7 +914,7 @@ func TestClose(t *testing.T) {
 	}
 
 	wf := w.WatchedFiles()
-	fileList := w.retrieveFileList()
+	_, fileList := w.retrieveFileList()
 
 	if len(wf) != len(fileList) {
 		t.Fatalf("expected len of wf to be %d, got %d", len(fileList), len(wf))
@@ -924,7 +924,7 @@ func TestClose(t *testing.T) {
 	w.Close()
 
 	wf = w.WatchedFiles()
-	fileList = w.retrieveFileList()
+	_, fileList = w.retrieveFileList()
 
 	// Close will be a no-op so there will still be len(fileList) files.
 	if len(wf) != len(fileList) {
@@ -963,7 +963,7 @@ func TestWatchedFiles(t *testing.T) {
 	}
 
 	wf := w.WatchedFiles()
-	fileList := w.retrieveFileList()
+	_, fileList := w.retrieveFileList()
 
 	if len(wf) != len(fileList) {
 		t.Fatalf("expected len of wf to be %d, got %d", len(fileList), len(wf))


### PR DESCRIPTION
This fixes a bug where the very first time a watched file is moved, it sends a "create" event instead of a "moved" event.
It behaves as expected the second+ time a file is moved.

This is because:
- `w.retrieveFileList()` is called to get a list of "new files".  If it sees a file get deleted because the value of `w.names` doesn't exist anymore, it calls `w.Remove(name)` which deletes that file from the w.files list. 
- Then, in  `w.pollEvents(fileList, evt, cancel)` is given the new files and compares it to w.files - if something is in w.files (the old list) but is not in newFiles, it's considered a "moved" event. Otherwise anything just in the newFiles but not in w.files is "created".
-- since retrieveFileList already called w.Remove and took the deleted file out of `w.files`, w.files is actually shorter than what’s returned by retrieveFileList- so it thinks it's a create.

I think this doesn't happen on subsequent file moves because that file isn't added back to the list, so it's not registered as a `ErrWatchedFileDeleted` event the second time since it's no longer in the list of w.names even though w.files is accurate.